### PR TITLE
feat: add role-based access control to IdentityManagerV2

### DIFF
--- a/src/IdentityManagerV2.sol
+++ b/src/IdentityManagerV2.sol
@@ -16,4 +16,9 @@ import "@openzeppelin/contracts/utils/Pausable.sol";
  */
 contract IdentityManagerV2 is AccessControl, ReentrancyGuard, Pausable {
     using ByteHasher for bytes;
+
+        ///////////////////////////////////////////////////////////////////////////////
+    ///                                  ROLES                                 ///
+    ///////////////////////////////////////////////////////////////////////////////
+
 }

--- a/src/IdentityManagerV2.sol
+++ b/src/IdentityManagerV2.sol
@@ -17,8 +17,10 @@ import "@openzeppelin/contracts/utils/Pausable.sol";
 contract IdentityManagerV2 is AccessControl, ReentrancyGuard, Pausable {
     using ByteHasher for bytes;
 
-        ///////////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////////
     ///                                  ROLES                                 ///
     ///////////////////////////////////////////////////////////////////////////////
-
+    bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
+    bytes32 public constant VERIFIER_ROLE = keccak256("VERIFIER_ROLE");
+    bytes32 public constant EMERGENCY_ROLE = keccak256("EMERGENCY_ROLE");
 }

--- a/src/IdentityManagerV2.sol
+++ b/src/IdentityManagerV2.sol
@@ -14,4 +14,6 @@ import "@openzeppelin/contracts/utils/Pausable.sol";
  * Includes batch operations, verification levels, expiration support, and comprehensive admin controls.
  * @dev This contract manages identity verification with enhanced security and administrative features.
  */
-contract IdentityManagerV2 is AccessControl, ReentrancyGuard, Pausable {}
+contract IdentityManagerV2 is AccessControl, ReentrancyGuard, Pausable {
+    using ByteHasher for bytes;
+}


### PR DESCRIPTION
# Pull Request
## Summary
This PR enhances the `IdentityManagerV2` contract with role-based access control and utility imports for future identity verification logic.

## Changes
- Added `ByteHasher` utility import with `using ByteHasher for bytes;`.
- Introduced **role constants** for access control:
  - `ADMIN_ROLE`
  - `VERIFIER_ROLE`
  - `EMERGENCY_ROLE`
- Added Natspec section header for **Roles** to improve readability.

## Motivation
These updates establish the foundation for fine-grained access control and future extensibility of identity verification operations.
