### PR TITLE
feat: add verifyAndExecute function to IdentityManagerV2

### DIFF
--- a/src/IdentityManagerV2.sol
+++ b/src/IdentityManagerV2.sol
@@ -172,17 +172,12 @@ contract IdentityManagerV2 is AccessControl, ReentrancyGuard, Pausable {
      * @param _actionId The World ID action identifier
      * @param _groupId The World ID group identifier (1 for orb, others for device)
      */
-    constructor(
-        address _worldId,
-        string memory _appId,
-        string memory _actionId,
-        uint256 _groupId
-    ) validAddress(_worldId) {
+    constructor(address _worldId, string memory _appId, string memory _actionId, uint256 _groupId)
+        validAddress(_worldId)
+    {
         worldId = IWorldID(_worldId);
         groupId = _groupId;
-        externalNullifier = abi
-            .encodePacked(abi.encodePacked(_appId).hashToField(), _actionId)
-            .hashToField();
+        externalNullifier = abi.encodePacked(abi.encodePacked(_appId).hashToField(), _actionId).hashToField();
 
         // Set up roles
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
@@ -228,12 +223,7 @@ contract IdentityManagerV2 is AccessControl, ReentrancyGuard, Pausable {
 
         // Verify World ID proof
         worldId.verifyProof(
-            root,
-            groupId,
-            abi.encodePacked(signal).hashToField(),
-            nullifierHash,
-            externalNullifier,
-            proof
+            root, groupId, abi.encodePacked(signal).hashToField(), nullifierHash, externalNullifier, proof
         );
 
         // Record nullifier usage
@@ -243,9 +233,7 @@ contract IdentityManagerV2 is AccessControl, ReentrancyGuard, Pausable {
         VerificationLevel level = groupId == 1 ? VerificationLevel.ORB : VerificationLevel.DEVICE;
 
         // Set expiration time
-        uint256 finalExpiration = expirationTimestamp == 0 
-            ? block.timestamp + DEFAULT_EXPIRATION 
-            : expirationTimestamp;
+        uint256 finalExpiration = expirationTimestamp == 0 ? block.timestamp + DEFAULT_EXPIRATION : expirationTimestamp;
 
         // Store verification
         _storeVerification(signal, userType, level, finalExpiration, nullifierHash, "");


### PR DESCRIPTION
# Pull Request
## Summary
This PR introduces the `verifyAndExecute` external function in **IdentityManagerV2**, enabling user verification via World ID proofs with proper validation, expiration handling, and event emission.

## Changes
- **Added**
  - `/// VERIFICATION FUNCTIONS` section header for clarity.
  - `verifyAndExecute` external function:
    - Validates nullifiers, prevents duplicate verification, and checks expiration.
    - Calls `worldId.verifyProof` to ensure proof authenticity.
    - Records nullifier usage.
    - Determines verification level (`ORB` vs. `DEVICE`) based on `groupId`.
    - Stores verification data via `_storeVerification`.
    - Emits `UserVerified` event.
- **Modified**
  - Refactored `constructor` formatting for readability.
- **Formatting**
  - Applied `forge fmt` for consistent style.

## Motivation
- Provides a secure, external entry point for verifying users against **World ID**.
- Ensures strong protection against:
  - Duplicate verifications (nullifier reuse).
  - Invalid or expired verification attempts.
- Establishes event-based transparency for off-chain indexing.

## Next Steps
- Add unit tests for `verifyAndExecute` covering:
  - Successful verification (ORB and DEVICE).
  - Duplicate nullifier rejection.
  - Expired timestamp reverts.
  - Already verified user reverts.
- Integrate with frontend flows for onboarding verified users.
